### PR TITLE
Disabling Text Selection

### DIFF
--- a/toggles.css
+++ b/toggles.css
@@ -1,6 +1,12 @@
 .slide {
   overflow: hidden;
   cursor: pointer;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 .slide .on,.slide .off,.slide .blob {
   float: left;


### PR DESCRIPTION
I've added CSS to disable text selection in most modern browsers. This will remove the visual "bug" when dragging the slider.
