### PR TITLE
Modest readme docs, state passed on toggle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,34 @@
 # jQuery Toggles
 
+
+```javascript
+
+// Simplest way:
+$('#myDiv').toggles();
+
+
+// With options (defaults shown below)
+$('#myDiv').toggles({
+    dragable: true,
+    clickable: true,
+    ontext: 'ON',
+    offtext: 'OFF',
+    on: true,
+    animtime: 300
+});
+
+
+// Getting notified of changes, and the new state:
+$('#myDiv').on('toggle', function (active) {
+    if (active) {
+        foo();
+    } else {
+        bar();
+    }
+});
+
+```
+
 http://simontabor.com/toggles/
 
 ## License (MIT)

--- a/toggles.js
+++ b/toggles.js
@@ -91,7 +91,7 @@
       if (o.clickable) {
         o.click.click(function(e) {
           if (e.target !=  blob[0] || !o.dragable) {
-            self.trigger('toggle');
+            self.trigger('toggle', !slide.hasClass('active'));
           }
         });
       }
@@ -102,7 +102,7 @@
         if (diff !== 0) {
         if (slide.hasClass('active')) {
           if (diff < (-w+h)/4) {
-            self.trigger('toggle');
+            self.trigger('toggle', !slide.hasClass('active'));
           }else{
             inner.animate({
               marginLeft: 0
@@ -110,14 +110,14 @@
           }
         }else{
           if (diff > (w-h)/4) {
-            self.trigger('toggle');
+            self.trigger('toggle', !slide.hasClass('active'));
           }else{
             inner.animate({
               marginLeft: -w+h
             },o.animtime/2);
           }
         }
-      }else if (o.clickable && e.type != 'mouseleave') self.trigger('toggle');
+      }else if (o.clickable && e.type != 'mouseleave') self.trigger('toggle', !slide.hasClass('active'));
       }
       if (o.dragable) {
         blob.on('mousedown',function(e) {


### PR DESCRIPTION
Things added in this commit:
- Small README.md addition to include a couple of simple examples, show the config option defaults, and how to listen for the toggle event.
- Addition of new state passed to the toggle event handlers so that people can easily get state.
