### PR TITLE
Compatibility with AMD and .noconflict()

### DIFF
--- a/toggles.js
+++ b/toggles.js
@@ -3,6 +3,16 @@
 Copyright 2013 Simon Tabor - MIT License
 https://github.com/simontabor/jquery-toggles / http://simontabor.com/labs/toggles
 */
+
+(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(['jquery'], factory);
+  } else {
+    factory(root.jQuery || root.Zepto || root.ender || root.$)
+  }
+})
+(this, function($) {
+
 $.fn['toggles'] = function(options) {
   options = options || {};
 
@@ -278,5 +288,5 @@ $.fn['toggles'] = function(options) {
 
 
   });
-
 };
+});


### PR DESCRIPTION
Hi,

I had to make a little change to make this plugin work with my code (we use requirejs, and we don't have a global $ variable for jQuery because some legacy imported contents uses Mootools).
